### PR TITLE
Removed deployment for the model2 UI

### DIFF
--- a/argocd/ai-llm-demo/kustomize/base/deployments/kustomization.yaml
+++ b/argocd/ai-llm-demo/kustomize/base/deployments/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - gradio-hftgi-rag-redis-model1.yaml
-  - gradio-hftgi-rag-redis-model2.yaml
+  # - gradio-hftgi-rag-redis-model2.yaml
   - hf-text-generation-inference-server-model1.yaml
   - hf-text-generation-inference-server-model2.yaml


### PR DESCRIPTION
While inference server is still being deployed , ui component for second model will not be deployed to make sure that metrics from the pod appearing in monitoring 